### PR TITLE
feature: Add meta tags for title and description of Open Graph and Tw…

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>X Clone</title>
     <link rel="stylesheet" href="/styles/index.css">
+    <link rel="shortcut icon" href="/assets/icons/x.svg" type="image/x-icon">
+
+    <meta name="description" content="This is a project that clones the skeleton UI of the Feed page of X (formerly Twitter).">
+
+    <!-- Open Graph meta tags -->
+    <meta property="og:title" content="X UI Clone">
+    <meta property="og:description" content="This is a project that clones the skeleton UI of the Feed page of X (formerly Twitter).">
+    <meta property="og:image" content="/assets/images/x_cover.jpeg">
+    <meta property="og:image:alt" content="X Cover Image">
+
+    <!-- Twitter Card meta tags -->
+    <meta name="twitter:title" content="X UI Clone">
+    <meta name="twitter:description" content="This is a project that clones the skeleton UI of the Feed page of X (formerly Twitter).">
+    <meta name="twitter:url" content="/">
+    <meta name="twitter:image:src" content="/assets/images/x_cover.jpeg">
+    <meta name="twitter:image:alt" content="X Cover Image">
 </head>
 <body>
     <h1>X Clone</h1>


### PR DESCRIPTION
# Description

Add some meta tags for description, Open Graph and Twitter Card.
When the link is shared in any Social Media, it should see the card with cover image, title and description.

# Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refractoring
- [ ] Performance improvement
- [ ] Scaffolding
 
# How to test
Use this site or any other Social Media site : <https://www.opengraph.xyz>
Paste this link in it to check if the Card is showing properly : <https://deploy-preview-1--x-clone-nk.netlify.app>